### PR TITLE
Repeater and Ram Improvements

### DIFF
--- a/src/main/java/org/tal/basiccircuits/BasicCircuits.java
+++ b/src/main/java/org/tal/basiccircuits/BasicCircuits.java
@@ -15,7 +15,7 @@ public class BasicCircuits extends CircuitLibrary {
                 shiftregister.class, transmitter.class, xor.class, decoder.class, encoder.class, pixel.class, pulse.class, not.class,
                 synth.class, srnor.class, terminal.class, router.class, ringcounter.class, iptransmitter.class, ipreceiver.class,
                 comparator.class, delay.class, repeater.class, nand.class, nor.class, xnor.class, segdriver.class, dregister.class, 
-                sram.class, bintobcd.class, display.class, burst.class };
+                sram.class, bintobcd.class, display.class, burst.class, watcher.class };
     }
 
     @Override

--- a/src/main/java/org/tal/basiccircuits/BasicCircuits.java
+++ b/src/main/java/org/tal/basiccircuits/BasicCircuits.java
@@ -15,7 +15,7 @@ public class BasicCircuits extends CircuitLibrary {
                 shiftregister.class, transmitter.class, xor.class, decoder.class, encoder.class, pixel.class, pulse.class, not.class,
                 synth.class, srnor.class, terminal.class, router.class, ringcounter.class, iptransmitter.class, ipreceiver.class,
                 comparator.class, delay.class, repeater.class, nand.class, nor.class, xnor.class, segdriver.class, dregister.class, 
-                sram.class, bintobcd.class, display.class, burst.class, watcher.class };
+                sram.class, bintobcd.class, display.class, burst.class, ramwatch.class };
     }
 
     @Override

--- a/src/main/java/org/tal/basiccircuits/display.java
+++ b/src/main/java/org/tal/basiccircuits/display.java
@@ -223,4 +223,11 @@ public class display extends Circuit {
         
         return true;
     }
+    @Override
+    protected void circuitShutdown() {
+        if (ram != null)
+           ram.getListeners().remove(ramListener);
+        if (receiver != null)
+           receiver.shutdown();
+    }
 }

--- a/src/main/java/org/tal/basiccircuits/dregister.java
+++ b/src/main/java/org/tal/basiccircuits/dregister.java
@@ -1,9 +1,14 @@
 
 package org.tal.basiccircuits;
 
+import java.io.IOException;
 import org.bukkit.command.CommandSender;
 import org.tal.redstonechips.circuit.Circuit;
+import org.tal.redstonechips.bitset.BitSet7;
 import org.tal.redstonechips.bitset.BitSetUtils;
+import org.tal.redstonechips.memory.Memory;
+import org.tal.redstonechips.memory.Ram;
+import org.tal.redstonechips.memory.RamListener;
 
 /**
  *
@@ -12,27 +17,74 @@ import org.tal.redstonechips.bitset.BitSetUtils;
 public class dregister extends Circuit {
     private static final int clockIdx = 0;
     private static final int resetIdx = 1;
-
+    
+    private Ram ram;
+    private RamListener ramListener;
+    private BitSet7 ramaddr;
+    
     @Override
     public void inputChange(int inIdx, boolean state) {
         if (inIdx==resetIdx && state) {
-            this.sendBitSet(BitSetUtils.clearBitSet);
+            if (ram != null)
+                ram.write(ramaddr, BitSetUtils.clearBitSet); //this will update the output
+            else this.sendBitSet(BitSetUtils.clearBitSet);
         } else if (inputBits.get(clockIdx)) {
-            sendBitSet(inputBits.get(2, outputs.length+2));
+            if (ram != null)
+                ram.write(ramaddr, inputBits.get(2, outputs.length+2)); //this will update the output
+            else this.sendBitSet(inputBits.get(2, outputs.length+2));
         }
     }
-
+    
+    class DRegisterRamListener implements RamListener {
+        @Override
+        public void dataChanged(Ram ram, BitSet7 address, BitSet7 data) {
+            if (ramaddr.equals(address))
+                sendBitSet(data);
+        }
+    }
+    
     @Override
     protected boolean init(CommandSender sender, String[] args) {
+        if (args.length >= 1)
+            if (args[0].startsWith("$")) {
+                try {
+                    if (args.length >= 2)
+                        ramaddr = BitSetUtils.intToBitSet(Integer.decode(args[1]));
+                    else
+                        ramaddr = BitSetUtils.clearBitSet;
+                    
+                    ram = (Ram)Memory.getMemory(args[0].substring(1), Ram.class);
+                } catch (IllegalArgumentException e) {
+                    error(sender, e.getMessage());
+                } catch (IOException e) {
+                    error(sender, e.getMessage());
+                }
+            } /*else if (channel==null) {
+                if (args[0].startsWith("#"))
+                    channel = args[0].substring(1);
+                else channel = args[0];
+            } */ else error(sender, "Invalid argument: " + args[0]);
+        
         if (inputs.length!=outputs.length+2) {
             sender.sendMessage("Expecting 2 more inputs than outputs. Found " + inputs.length + " input(s) and " + outputs.length + " output(s).");
             return false;
-        } else {
-            if (sender!=null) resetOutputs();
-            return true;
         }
+        if (sender!=null) resetOutputs();
+        
+        if (ram != null) {
+            ramListener = new DRegisterRamListener();
+            ram.addListener(ramListener);
+            this.sendBitSet(ram.read(ramaddr));
+            info(sender, "Created "+outputs.length+"-bit register backed by memory: "+ram.getId()+"@"+Integer.toHexString(BitSetUtils.bitSetToUnsignedInt(ramaddr, 0, ramaddr.length())));
+        } else
+            info(sender, "Created "+outputs.length+"-bit register.");
+        return true;
     }
-
+    @Override
+    protected void circuitShutdown() {
+        if (ram != null)
+           ram.getListeners().remove(ramListener);
+    }
     @Override
     protected boolean isStateless() {
         return false;

--- a/src/main/java/org/tal/basiccircuits/ramwatch.java
+++ b/src/main/java/org/tal/basiccircuits/ramwatch.java
@@ -13,7 +13,7 @@ import org.tal.redstonechips.memory.RamListener;
 /**
  *
  */
-public class watcher extends Circuit {
+public class ramwatch extends Circuit {
     private Ram ram;
     private RamListener ramListener;
     private BitSet7 ramaddr;
@@ -24,7 +24,7 @@ public class watcher extends Circuit {
     public void inputChange(int inIdx, boolean state) {
     }
     
-    class WatcherRamListener implements RamListener {
+    class RamWatchListener implements RamListener {
         @Override
         public void dataChanged(Ram ram, BitSet7 address, BitSet7 data) {
             if (inputBits.get(0) & (ramaddr == null || ramaddr.equals(address))) {
@@ -64,7 +64,7 @@ public class watcher extends Circuit {
         if (sender!=null) resetOutputs();
         
         if (ram != null) {
-            ramListener = new WatcherRamListener();
+            ramListener = new RamWatchListener();
             ram.addListener(ramListener);
             
             if (ramaddr==null)

--- a/src/main/java/org/tal/basiccircuits/ramwatch.java
+++ b/src/main/java/org/tal/basiccircuits/ramwatch.java
@@ -18,8 +18,6 @@ public class ramwatch extends Circuit {
     private RamListener ramListener;
     private BitSet7 ramaddr;
     
-    private PulseOff pulseOff = new PulseOff();
-    
     @Override
     public void inputChange(int inIdx, boolean state) {
     }
@@ -29,7 +27,7 @@ public class ramwatch extends Circuit {
         public void dataChanged(Ram ram, BitSet7 address, BitSet7 data) {
             if (inputBits.get(0) & (ramaddr == null || ramaddr.equals(address))) {
                 sendOutput(0, true);
-                redstoneChips.getServer().getScheduler().scheduleSyncDelayedTask(redstoneChips, pulseOff, 1);
+		sendOutput(0, false);
             }
         }
     }
@@ -81,13 +79,6 @@ public class ramwatch extends Circuit {
     protected void circuitShutdown() {
         if (ram != null)
            ram.getListeners().remove(ramListener);
-    }
-    
-    class PulseOff implements Runnable {
-        @Override
-        public void run() {
-            sendOutput(0, false);
-        }
     }
     
     @Override

--- a/src/main/java/org/tal/basiccircuits/repeater.java
+++ b/src/main/java/org/tal/basiccircuits/repeater.java
@@ -9,15 +9,52 @@ import org.tal.redstonechips.circuit.Circuit;
  * @author Tal Eisenberg
  */
 public class repeater extends Circuit {
-
+    int outputSets;
+    int outputSetSize;
+    
     @Override
     public void inputChange(int idx, boolean state) {
-        if (idx==0) for (int i=0; i<outputs.length; i++) sendOutput(i, state);
+        if (outputSets==0)
+            for (int i=0; i<outputs.length; i++) sendOutput(i, state);
+        else
+            for (int j=0; j<outputSets; j++)
+                sendOutput(j*outputSetSize+idx, state);
     }
 
     @Override
-    protected boolean init(CommandSender sender, String[] args) {
+    protected boolean init(CommandSender sender, String[] args) { 
+        if (inputs.length<1) {
+            error(sender, "Expecting at least 1 input pin.");
+            return false;
+        }
+        if (outputs.length<1) {
+            error(sender, "Expecting at least 1 output pin.");
+            return false;
+        }
+        
+        if (inputs.length == 1)
+            outputSets = 0; //optimize for original function
+        else
+            outputSets = outputs.length/inputs.length;
+        
+        if (outputSets != 0) {
+            if (outputs.length != inputs.length*outputSets) {
+                error(sender, "Tried to split "+outputs.length+" into "+outputSets+", expected "+(inputs.length*outputSets)+" outputs.");
+                return false;
+            }
+            outputSetSize = outputs.length/outputSets;
+            if (outputSets==1)
+                info(sender, "Repeating "+outputs.length+" bits.");
+            else
+                info(sender, "Splitting "+inputs.length+" bits into "+outputs.length+", "+outputSets+" sets");
+        } else {
+            outputSetSize = 0; //not used
+            if (outputs.length==1)
+                info(sender, "Repeating 1 bit.");
+            else
+                info(sender, "Splitting 1 bit into "+outputs.length+".");
+        }
+        
         return true;
     }
-
 }

--- a/src/main/java/org/tal/basiccircuits/sram.java
+++ b/src/main/java/org/tal/basiccircuits/sram.java
@@ -279,7 +279,8 @@ public class sram extends Circuit implements RCTypeReceiver, RamListener {
 
     @Override
     public void circuitShutdown() {
-        memory.release();
+        memory.getListeners().remove(this);
+	memory.release();
     }
     
     class MemoryLineSource implements LineSource {

--- a/src/main/java/org/tal/basiccircuits/watcher.java
+++ b/src/main/java/org/tal/basiccircuits/watcher.java
@@ -1,0 +1,97 @@
+
+package org.tal.basiccircuits;
+
+import java.io.IOException;
+import org.bukkit.command.CommandSender;
+import org.tal.redstonechips.circuit.Circuit;
+import org.tal.redstonechips.bitset.BitSet7;
+import org.tal.redstonechips.bitset.BitSetUtils;
+import org.tal.redstonechips.memory.Memory;
+import org.tal.redstonechips.memory.Ram;
+import org.tal.redstonechips.memory.RamListener;
+
+/**
+ *
+ */
+public class watcher extends Circuit {
+    private Ram ram;
+    private RamListener ramListener;
+    private BitSet7 ramaddr;
+    
+    private PulseOff pulseOff = new PulseOff();
+    
+    @Override
+    public void inputChange(int inIdx, boolean state) {
+    }
+    
+    class WatcherRamListener implements RamListener {
+        @Override
+        public void dataChanged(Ram ram, BitSet7 address, BitSet7 data) {
+            if (inputBits.get(0) & (ramaddr == null || ramaddr.equals(address))) {
+                sendOutput(0, true);
+                redstoneChips.getServer().getScheduler().scheduleSyncDelayedTask(redstoneChips, pulseOff, 1);
+            }
+        }
+    }
+    
+    @Override
+    protected boolean init(CommandSender sender, String[] args) {
+        if (args.length >= 1) {
+            if (args[0].startsWith("$")) {
+                try {
+                    if (args.length >= 2)
+                        ramaddr = BitSetUtils.intToBitSet(Integer.decode(args[1]));
+                    else
+                        ramaddr = null;
+                    
+                    ram = (Ram)Memory.getMemory(args[0].substring(1), Ram.class);
+                } catch (IllegalArgumentException e) {
+                    error(sender, e.getMessage());
+                } catch (IOException e) {
+                    error(sender, e.getMessage());
+                }
+            } else error(sender, "Invalid argument: " + args[0]);
+        } else {
+            error(sender, "Expected at least one argument, the ram to watch.");
+            return false;
+        }
+        
+        if (inputs.length < 1 || outputs.length < 1) {
+            error(sender, "Expected at least one input and output. Found " + inputs.length + " input(s) and " + outputs.length + " output(s).");
+            return false;
+        }
+        
+        if (sender!=null) resetOutputs();
+        
+        if (ram != null) {
+            ramListener = new WatcherRamListener();
+            ram.addListener(ramListener);
+            
+            if (ramaddr==null)
+                info(sender, "Created ram watcher targeting entirety of $"+ram.getId());
+            else
+                info(sender, "Created ram watcher targeting $"+ram.getId()+"@"+Integer.toHexString(BitSetUtils.bitSetToUnsignedInt(ramaddr, 0, ramaddr.length())));
+        } else {
+            error(sender, "Couldn't find ram to watch.");
+            return false;
+        }
+        return true;
+    }
+    @Override
+    protected void circuitShutdown() {
+        if (ram != null)
+           ram.getListeners().remove(ramListener);
+    }
+    
+    class PulseOff implements Runnable {
+        @Override
+        public void run() {
+            sendOutput(0, false);
+        }
+    }
+    
+    @Override
+    protected boolean isStateless() {
+        return false;
+    }
+}


### PR DESCRIPTION
This is series of updates I created while working on a RedstoneChips project on my server. It addresses a few shortcomings and issues I found while working with your plugin. (Note that I love your plugin, it's just that there were a few things I couldn't get it to do.)

This pull request encompasses four main features:
- Fixed a bug I discovered in the display chip, which causes it to not unregister a ram listener. (This means the display would update even after destruction.)
- The repeater chip can now repeat entire sets of bits, instead of just one. I'll describe this a little more below.
- The dregister chip can now be backed by ram. This is useful for making "hardware" controlled by locations in your virtual ram.
- The watcher chip generates a clock signal whenever a watched ram address changes, which is useful in conjuction with the ram-backed dregister.

The repeater chip has new features which I think greatly increase it's usability. While before it could only repeat/split 1 bit, now it can do so with as many bits as you choose. This allows it to function as a 16-bit repeater, or a 16 to 32-bit splitter, or so on. Note also that my modifications do not change it's old behavior at all, assuming the old chips only had one input. A 1 input repeater will still repeat to all outputs.

One issue on which I was a little confused was as to whether or not my watcher should output a 0-tick or 1-tick clock signal. I ended up going with the 1-tick variant, but this could easily be changed. EDIT: ramwatch outputs a 0-tick signal now.

There are more details about the modifications I made in the relevant commits.

EDIT: Updated circuitdocs for the repeater, dregister, and ramwatch chips are available in this pull request: http://github.com/eisental/RedstoneChips/pull/62
They can be accessed as HTML through GitHub pages here: http://jpfx1342.github.com/RedstoneChips/circuitdocs/index.html
