### PR TITLE
Fix ArrayIndexOutOfBoundsException on SRAM

### DIFF
--- a/src/main/java/org/redstonechips/basiccircuits/synth.java
+++ b/src/main/java/org/redstonechips/basiccircuits/synth.java
@@ -98,8 +98,9 @@ public class synth extends Circuit {
             }
             pitch = pitchIndex[index];
         } else {
-            if (val>=24) {
+            if (val>24) {
                 if (chip.hasListeners()) debug("pitch value is too high: " + val);
+                return;
             }
             pitch = (byte)val;
         }


### PR DESCRIPTION
Employ https://github.com/socram8888/RedstoneChips/commit/641d6f1a5d6e4ad38fbbc470283ad9a7dba35558 to fix an ArrayIndexOutOfBoundsException when creating a new SRAM chip.

This was the stack trace:

```
[18:11:45 WARN]: java.lang.ArrayIndexOutOfBoundsException: 1
[18:11:45 WARN]:        at org.redstonechips.circuit.Circuit.writeBits(Circuit.java:213)
[18:11:45 WARN]:        at org.redstonechips.basiccircuits.sram.readMemory(sram.java:160)
[18:11:45 WARN]:        at org.redstonechips.basiccircuits.sram.init(sram.java:129)
[18:11:45 WARN]:        at org.redstonechips.circuit.Circuit.initalizeCircuit(Circuit.java:383)
[18:11:45 WARN]:        at org.redstonechips.chip.ChipManager.activateChip(ChipManager.java:94)
[18:11:45 WARN]:        at org.redstonechips.chip.ChipManager.maybeCreateAndActivateChip(ChipManager.java:64)
[18:11:45 WARN]:        at org.redstonechips.chip.ChipManager.maybeCreateAndActivateChip(ChipManager.java:47)
[18:11:45 WARN]:        at org.redstonechips.RCBukkitEventHandler.onPlayerInteract(RCBukkitEventHandler.java:204)
[18:11:45 WARN]:        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[18:11:45 WARN]:        at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
[18:11:45 WARN]:        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
[18:11:45 WARN]:        at java.lang.reflect.Method.invoke(Unknown Source)
[18:11:45 WARN]:        at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:292)
[18:11:45 WARN]:        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62)
[18:11:45 WARN]:        at org.bukkit.plugin.SimplePluginManager.fireEvent(Simpl
ePluginManager.java:501)
[18:11:45 WARN]:        at org.bukkit.plugin.SimplePluginManager.callEvent(Simpl
ePluginManager.java:486)
[18:11:45 WARN]:        at org.bukkit.craftbukkit.v1_7_R3.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:195)
[18:11:45 WARN]:        at net.minecraft.server.v1_7_R3.PlayerInteractManager.interact(PlayerInteractManager.java:383)
[18:11:45 WARN]:        at net.minecraft.server.v1_7_R3.PlayerConnection.a(PlayerConnection.java:656)
[18:11:45 WARN]:        at net.minecraft.server.v1_7_R3.PacketPlayInBlockPlace.a(SourceFile:60)
[18:11:45 WARN]:        at net.minecraft.server.v1_7_R3.PacketPlayInBlockPlace.handle(SourceFile:9)
[18:11:45 WARN]:        at net.minecraft.server.v1_7_R3.NetworkManager.a(NetworkManager.java:178)
[18:11:45 WARN]:        at net.minecraft.server.v1_7_R3.ServerConnection.c(ServerConnection.java:76)
[18:11:45 WARN]:        at net.minecraft.server.v1_7_R3.MinecraftServer.v(MinecraftServer.java:669)
[18:11:45 WARN]:        at net.minecraft.server.v1_7_R3.DedicatedServer.v(DedicatedServer.java:321)
[18:11:45 WARN]:        at net.minecraft.server.v1_7_R3.MinecraftServer.u(MinecraftServer.java:559)
[18:11:45 WARN]:        at net.minecraft.server.v1_7_R3.MinecraftServer.run(MinecraftServer.java:472)
[18:11:45 WARN]:        at net.minecraft.server.v1_7_R3.ThreadServerApplication.run(SourceFile:628)
```

Was caused by method readMemory which called writeBits with size wordLength, though memory.read returns a variable-sized array.
